### PR TITLE
Repeat for surround_add() + Highlighting + fix for function replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 1. Provides key mapping to add surrounding characters.( visually select then press `s<char>` or press `sa{motion}{char}`)
 2. Provides key mapping to replace surrounding characters.( `sr<from><to>` )
 3. Provides key mapping to delete surrounding characters.( `sd<char>` )
-4. `ss` repeats last surround command. (Doesn't work with add)
+4. `ss` repeats last surround command.
 
 #### Normal Mode - Surround Mode
 

--- a/lua/surround/init.lua
+++ b/lua/surround/init.lua
@@ -73,7 +73,7 @@ function M.surround_add(op_mode, surrounding, motion)
 			break
 		end
 	end
-	if char_pairs == nil then
+	if char_pairs == nil and char ~= "f" then
 		return
 	end
 
@@ -260,7 +260,8 @@ function M.surround_replace(
 	cursor_position_relative,
 	context,
 	char_1,
-	char_2
+	char_2,
+	func_name
 )
 	local surround_pairs = vim.g.surround_pairs
 	local n = 0
@@ -311,19 +312,21 @@ function M.surround_replace(
 		end
 
 		-- Get new funcname
-		local func_name = utils.user_input("funcname: ")
+		if not func_name then
+			func_name = utils.user_input("funcname: ")
+		end
 
 		-- Delete old function
 		context[indexes[FUNCTION][LINE]] = string.remove(
 			context[indexes[FUNCTION][LINE]],
-			indexes[1][COLUMN],
-			indexes[2][COLUMN]
+			indexes[FUNCTION][COLUMN],
+			indexes[OPENING][COLUMN]
 		)
 
 		-- Add new function
 		context[indexes[FUNCTION][LINE]] = string.insert(
 			context[indexes[FUNCTION][LINE]],
-			indexes[1][COLUMN],
+			indexes[FUNCTION][COLUMN],
 			func_name
 		)
 	elseif char_1 == "f" then
@@ -374,7 +377,9 @@ function M.surround_replace(
 		end
 
 		-- Get new funcname
-		local func_name = utils.user_input("funcname: ")
+		if not func_name then
+			func_name = utils.user_input("funcname: ")
+		end
 		context[indexes[OPENING][LINE]] = string.set(context[indexes[OPENING][LINE]], indexes[OPENING][COLUMN], "(")
 		context[indexes[CLOSING][LINE]] = string.set(context[indexes[CLOSING][LINE]], indexes[CLOSING][COLUMN], ")")
 		context[indexes[OPENING][LINE]] = string.insert(
@@ -429,7 +434,7 @@ function M.surround_replace(
 	if not is_toggle then
 		vim.g.surround_last_cmd = {
 			"surround_replace",
-			{ false, vim.NIL, vim.NIL, vim.NIL, vim.NIL, vim.NIL, char_1, char_2 },
+			{ false, vim.NIL, vim.NIL, vim.NIL, vim.NIL, vim.NIL, char_1, char_2, func_name },
 		}
 	end
 end

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -210,8 +210,6 @@ local function table_keys(t)
 	return keys
 end
 
-local function highlight(start_pos, end_pos, duration) end
-
 local function has_value(tab, val)
 	for index, value in ipairs(tab) do
 		if value == val then
@@ -385,6 +383,27 @@ local function get_motion()
 	return count..motion
 end
 
+local function highlight_motion_selection()
+	-- this function assumes that '[ and '] were manually set before
+	local beg_mark = vim.api.nvim_buf_get_mark(0, "[")
+	local end_mark = vim.api.nvim_buf_get_mark(0, "]")
+	local ext_mark = vim.api.nvim_buf_set_extmark(
+		0,
+		vim.g.surround_namespace,
+		beg_mark[1] - 1,
+		beg_mark[2],
+		{
+			end_line = end_mark[1] - 1,
+			end_col = end_mark[2] + 1,
+			hl_group = "Visual",
+			priority = 1000
+		}
+	)
+	-- force a redraw of the window to show highlight immediately
+	vim.api.nvim_command(":redraw")
+	return ext_mark
+end
+
 return {
 	tprint = tprint,
 	has_value = has_value,
@@ -402,5 +421,6 @@ return {
 	quote = quote,
 	get = get,
 	map = map,
-	omaps = omaps
+	omaps = omaps,
+	highlight_motion_selection = highlight_motion_selection,
 }

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -1,3 +1,3 @@
 function! SurroundAddOperatorMode(type, ...)
-	lua require"surround".surround_add_operator_mode()
+	lua require"surround".surround_add(true)
 endfunction

--- a/plugin/surround.vim
+++ b/plugin/surround.vim
@@ -1,3 +1,0 @@
-function! SurroundAddOperatorMode(type, ...)
-	lua require"surround".surround_add(true)
-endfunction


### PR DESCRIPTION
This PR implements a way to repeat additions by recording the user's motion and desired character and inputting them as arguments to the next function call on repeat(). The vimL file became obsolete and the one no-op function I needed to set the motion marks (`'[`/`']`) is added in setup().

Additionally, this PR adds highlighting of the text that the motion goes over. I chose to hardcode the "Visual" highlight group as I don't think there is much point in having this configurable. I removed the highlight group that was set in setup() that was also hardcoded and not used anywhere.
Closes #13

There is also a small fix that makes replacing function names work correctly again.

Github makes the diff look a little noisy, so it's probably easier to look at it in two parts:
+ Here is the diff for just the refactor: https://github.com/blackCauldron7/surround.nvim/commit/00c384773a5a0b7cd556113dc7b3ab5799f6fdbc
+ This is the diff for the real additions: https://github.com/blackCauldron7/surround.nvim/compare/00c384773a5a0b7cd556113dc7b3ab5799f6fdbc...96b5c71