### PR TITLE
Feature: allow the use of arbitrary brackets (e.g. tags) via aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,25 @@ use {
 ### Format: for **vimscript** `let g:surround_<option>` and for **lua** `vim.g.surround_<option>`
 
 - `prefix`: prefix for sandwich mode. `(default: s)`
-- `pairs`: dictionary or lua table of form `{ nestable: {{},...}, linear: {{},....} }` where linear is an array of arrays which contain non nestable pairs of surrounding characters first opening and second closing like ", ' and nestable is an array of arrays which contain nestable pairs of surrounding characters like (, {, [. Default:
+- `pairs`: dictionary or lua table of form `{ nestable: {{},...}, linear: {{},....} }` where linear is an array of arrays which contain non-nestable pairs of surrounding characters first opening and second closing like ", ' and nestable is an array of arrays which contain nestable pairs of surrounding characters like (, {, [. The key to each pair can be used as an alias instead of either value. For single-character pairs, this alias is optional and you can just use either value. For pairs that use multiple characters per bracket, an alias is required. You can for example set ```pairs = { linear = { Q = {'"""','"""'} } }``` to use Q to add triple double quotes around selected text. The key "f" is used to add/replace functions, configuring it for a pair will override that functionality.
+  + Aliases must be a single letter.
+  + Aliases are case-sensitive.
+  + Aliases must be unique across the entire `pairs` table.
+  + When adding your own pairs, you do not need to specify the defaults. Your own values will be added to the default table and overwrite aliases when necessary.
+  + Defaults:
 ```lua
 {
-  nestable = {{"(", ")"}, {"[", "]"}, {"{", "}"}},
-  linear = {{"'", "'"}, {'"', '"'}}
+  nestable = {
+    b = { "(", ")" },
+    s = { "[", "]" },
+    B = { "{", "}" },
+    a = { "<", ">" }
+    },
+  linear = {
+    q = { "'", "'" },
+    t = { "`", "`" },
+    d = { '"', '"' }
+  },
 }
 ```
 - `context_offset`: number of lines to look for above and below the current line while searching for nestable pairs. `(default: 100)`
@@ -81,6 +95,7 @@ use {
 - `brackets`: an array of items to be considered as brackets while cycling through them. `(default: ["(", "{", "["])`
 - `map_insert_mode`: whether to load insert mode mappings or not. `(default: true)`
 - `space_on_closing_char`: if the closing char should add surround space rather than the opening char. `(default: false)`
+- `space_on_alias`: if the alias should add surround space. `(default: false)`
 
 ### or pass a lua table to the setup function
 
@@ -94,8 +109,8 @@ require"surround".setup {
   brackets = {"(", '{', '['},
   space_on_closing_char = false,
   pairs = {
-    nestable = {{"(", ")"}, {"[", "]"}, {"{", "}"}},
-    linear = {{"'", "'"}, {"`", "`"}, {'"', '"'}}
+    nestable = { b = { "(", ")" }, s = { "[", "]" }, B = { "{", "}" }, a = { "<", ">" } },
+    linear = { q = { "'", "'" }, t = { "`", "`" }, d = { '"', '"' }
   },
   prefix = "s"
 }
@@ -104,7 +119,7 @@ require"surround".setup {
 ## Caveats
 
 1. Only supports neovim and always will because it's written in lua which is neovim exclusive.
-1. Doesn't support python docstrings and html tags yet.
+1. ~~Doesn't support python docstrings and html tags yet.~~ Either can be added to the `pairs` table with an alias as shortcut. (No dynamic tags yet, though. You need to add the tags you want beforehand.)
 1. No vim docs(idk how to make them. Need help)
 1. No `.` repeat support(idk how to achieve this help would be appreciated.) (although there is a mapping `ss` only available in sandwich mode which repeats last surround command.)
 

--- a/lua/surround/init.lua
+++ b/lua/surround/init.lua
@@ -590,10 +590,21 @@ function M.set_keymaps()
 
 	if vim.g.surround_map_insert_mode then
 		-- Insert Mode Ctrl-S mappings
-		for _, pair in ipairs(vim.g.surround_pairs_flat) do
-			map("i", "<c-s>" .. pair[OPENING], pair[OPENING] .. pair[CLOSING] .. "<left>")
-			map("i", "<c-s>" .. pair[OPENING] .. " ", pair[OPENING] .. "  " .. pair[CLOSING] .. "<left><left>")
-			map("i", "<c-s>" .. pair[OPENING] .. "<c-s>", pair[OPENING] .. "<cr>" .. pair[CLOSING] .. "<esc>O")
+		for key, pair in pairs(vim.g.surround_pairs_flat) do
+			if #pair[OPENING] == 1 then
+				map("i", "<c-s>" .. pair[OPENING], pair[OPENING] .. pair[CLOSING] .. "<left>")
+				map("i", "<c-s>" .. pair[OPENING] .. " ", pair[OPENING] .. "  " .. pair[CLOSING] .. "<left><left>")
+				map("i", "<c-s>" .. pair[OPENING] .. "<c-s>", pair[OPENING] .. "<cr>" .. pair[CLOSING] .. "<esc>O")
+			end
+
+			local left = ""
+			for _ in string.gmatch(pair[CLOSING], ".") do
+				left = left .. "<left>"
+			end
+
+			map("i", "<c-s>" .. key, pair[OPENING] .. pair[CLOSING] .. left)
+			map("i", "<c-s>" .. key .. " ", pair[OPENING] .. "  " .. pair[CLOSING] .. left .. "<left>")
+			map("i", "<c-s>" .. key .. "<c-s>", pair[OPENING] .. "<cr>" .. pair[CLOSING] .. "<esc>O")
 		end
 	end
 end

--- a/lua/surround/init.lua
+++ b/lua/surround/init.lua
@@ -65,17 +65,8 @@ function M.surround_add(op_mode, surrounding, motion)
 
 	-- Get the pair to add
 	local surround_pairs = vim.g.surround_pairs
-	local all_pairs = table.merge(surround_pairs.nestable, surround_pairs.linear)
-	local char_pairs
-	for _, pair in ipairs(all_pairs) do
-		if table.contains(pair, char) then
-			char_pairs = pair
-			break
-		end
-	end
-	if char_pairs == nil and char ~= "f" then
-		return
-	end
+	local char_pairs = utils.get_char_pair(char)
+	if char_pairs == nil and char ~= "f" then return end
 
 	local space = ""
 	if vim.g.surround_space_on_closing_char then
@@ -348,23 +339,19 @@ function M.surround_replace(
 		end
 
 		-- Get the pair to replace with
-		local all_pairs = table.merge(surround_pairs.nestable, surround_pairs.linear)
-		local char_2_pairs
-		for _, pair in ipairs(all_pairs) do
-			if table.contains(pair, char_2) then
-				char_2_pairs = pair
-				break
-			end
-		end
-		if char_2_pairs == nil then
-			return
-		end
+		local char_2_pairs = utils.get_char_pair(char_2)
+		if char_2_pairs == nil then return end
 
 		-- Replace surrounding brackets with char_2 and remove function
+		context[indexes[CLOSING][LINE]] = string.set(
+			context[indexes[CLOSING][LINE]],
+			indexes[CLOSING][COLUMN],
+			char_2_pairs[CLOSING]
+		)
 		context[indexes[OPENING][LINE]] = string.set(
 			context[indexes[OPENING][LINE]],
 			indexes[OPENING][COLUMN],
-			char_2_pairs[1]
+			char_2_pairs[OPENING]
 		)
 		context[indexes[CLOSING][LINE]] = string.set(
 			context[indexes[CLOSING][LINE]],
@@ -406,17 +393,9 @@ function M.surround_replace(
 		end
 
 		-- Get the pair to replace with
-		local all_pairs = table.merge(surround_pairs.nestable, surround_pairs.linear)
-		local char_2_pairs
-		for _, pair in ipairs(all_pairs) do
-			if table.contains(pair, char_2) then
-				char_2_pairs = pair
-				break
-			end
-		end
-		if char_2_pairs == nil then
-			return
-		end
+		local char_2_pairs = utils.get_char_pair(char_2)
+		if char_2_pairs == nil then return end
+
 		-- Replace char_1 with char_2
 		context[indexes[OPENING][LINE]] = string.set(
 			context[indexes[OPENING][LINE]],

--- a/lua/surround/parser.lua
+++ b/lua/surround/parser.lua
@@ -225,9 +225,7 @@ end
 local function get_surround_pair(buffer, cursor_position, surrounding_char,
                                  includes, n)
   local surround_pairs = vim.g.surround_pairs
-  -- If the character is not in the pairs table return an emoty string.
-  local all_pairs = vim.tbl_flatten(table.merge(surround_pairs.nestable,
-                                                surround_pairs.linear))
+  local all_pairs = vim.g.surround_pairs_flat
   local special_char = {"f"}
   for _, char in ipairs(special_char) do
     table.insert(all_pairs, #all_pairs + 1, char)

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -261,6 +261,14 @@ local function get_surround_chars()
 	return surrounding
 end
 
+local function get_char_pair(char)
+	for _, pair in pairs(vim.g.surround_pairs_flat) do
+		if table.contains(pair, char) then
+			return pair
+		end
+	end
+end
+
 local function map(table, func)
 	local t = {}
 	for k,v in pairs(table) do
@@ -414,6 +422,7 @@ return {
 	get_visual_pos = get_visual_pos,
 	get_operator_pos = get_operator_pos,
 	get_motion = get_motion,
+	get_char_pair = get_char_pair,
 	get_surround_chars = get_surround_chars,
 	get_char = get_char,
 	clear_output_buffer = clear_output_buffer,

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -18,6 +18,17 @@ function table.merge(t1, t2)
 	return tmp
 end
 
+function table.merge_preserve_keys(t1, t2)
+	local tmp = {}
+	for k, v in pairs(t1) do
+		tmp[k]=v
+	end
+	for k, v in pairs(t2) do
+		tmp[k]=v
+	end
+	return tmp
+end
+
 function table.contains(tbl, string)
 	for k, v in pairs(tbl) do
 		if type(v) == "table" then
@@ -234,26 +245,32 @@ local function get_char()
 	end
 end
 
-local MAP_KEYS = { b = "(", B = "{", f = "f" }
-local function get_surround_chars()
-	vim.api.nvim_command(':echo "(Surround) Character: "')
+local function get_surround_chars(surrounding)
+	if not surrounding then
+		vim.api.nvim_command(':echo "(Surround) Character: "')
+		_, surrounding = get_char()
 
-	local _, surrounding = get_char()
+		-- 27 is <ESC>
+		if surrounding == 27 then return nil end
 
-	-- 27 is <ESC>
-	if surrounding == 27 then return nil end
-
-	clear_output_buffer()
-	-- escape potential " character
-	if not string.isalnum(surrounding) then
-		vim.api.nvim_command(':echomsg "(Surround) Character: \\' .. surrounding .. '"')
-	else
-		vim.api.nvim_command(':echomsg "(Surround) Character: ' .. surrounding .. '"')
+		clear_output_buffer()
+		-- escape characters
+		if not string.isalnum(surrounding) then
+			vim.api.nvim_command(':echomsg "(Surround) Character: \\' .. surrounding .. '"')
+		else
+			vim.api.nvim_command(':echomsg "(Surround) Character: ' .. surrounding .. '"')
+		end
 	end
 
-	for i, v in pairs(MAP_KEYS) do
+	for i,v in pairs(vim.g.surround_pairs_flat) do
 		if surrounding == i then
-			surrounding = v
+			local sa = vim.g.surround_space_on_alias
+			local sc = vim.g.surround_space_on_closing_char
+			if sa then
+				surrounding = (sc and v[2]) or v[1]
+			else
+				surrounding = (sc and v[1]) or v[2]
+			end
 			break
 		end
 	end


### PR DESCRIPTION
This PR builds on top of #37 (the first four commits). I just split this into 2 PRs since they are each already pretty large on their own.

This PR starts out with a refactor of parser.lua by consolidating all the `get_[non_]nested_pair()` and `get_surrounding_function()` functions and gave them the ability to look for multi-character brackets. I also split out another function with code that was copy-pasted SIX (!) times in there.

While at it, I also added the ability to remove and thus change the surrounding spacing. In normal mode, `sr()` will now remove spaces after the opening bracket and before the closing bracket and then add the brackets back without the space.
(was mentioned in #31 [here](https://github.com/blackCauldron7/surround.nvim/issues/31#issuecomment-1001875999))

Diff of just the refactor and space changing fix: https://github.com/blackCauldron7/surround.nvim/compare/96b5c71b2b680b000728b89faa83a7f8467a9bf6...cfd6f16a367c7f55522238379a1eefcaec2cba19

---

After that everything is to allow for arbitrary brackets via aliases. The new way to setup the `pairs` table would be:
```lua
pairs = {
  nestable = {
    b = { "(", ")" },
    s = { "[", "]" },
    B = { "{", "}" },
    a = { "<", ">" }
    },
  linear = {
    q = { "'", "'" },
    t = { "`", "`" },
    d = { '"', '"' }
  },
}
```
These are also the new default values. If the pair is composed of only single-character brackets, either bracket can be used to add/replace/delete surroundings. If the brackets are build out of multiple characters, the key of the table must be used as an alias (only single-character keys allowed for now)
Example:
```lua
pairs = {
  nestable = {
    d = { "<div>", "</div>" },
  },
}
```
This setting would allow you to add surround div tags by using `d` as the alias (i.e. `saiwd` will surround the word under the cursor with this tag). There is also a new setting `space_on_alias`, that should be self-explanatory here.
Closes #36 
Partially implements #31 (no dynamic "buns" 😢, I have no idea right now how to approach that to make it work with `replace()` and `delete()`)

Diff: https://github.com/blackCauldron7/surround.nvim/compare/a6ba7a151dd316069d1e1252eabbeff637bd0744...951e44f3890b44d2233e7988b6e2fa29e2b15757

