### PR TITLE
feat: disable input prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ use {
 }
 ```
 - `context_offset`: number of lines to look for above and below the current line while searching for nestable pairs. `(default: 100)`
+- `prompt`: whether to print a prompt in the command window asking for input. `(default: true)`
 - `load_autogroups`: whether to load inbuilt autogroups or not. `(default: false)`
 - `mappings_style`: "surround" or "sandwich" `(default: sandwich)`
 - `load_keymaps`: whether to load inbuilt keymaps or not. `(default: true)`

--- a/lua/surround/init.lua
+++ b/lua/surround/init.lua
@@ -175,9 +175,15 @@ function M.surround_delete(char)
 	local n = 0
 	if not char then
 		char = utils.get_surround_chars()
+		if char == nil then
+			return
+		end
 		if utils.has_value({ "2", "3", "4", "5", "6", "7", "8", "9" }, char) then
 			n = tonumber(char) - 1
 			char = utils.get_surround_chars()
+			if char == nil then
+				return
+			end
 		end
 	end
 
@@ -263,11 +269,21 @@ function M.surround_replace(
 	if not is_toggle then
 		if not char_1 then
 			char_1 = utils.get_surround_chars()
+			if char_1 == nil then
+				return
+			end
+
 			if utils.has_value({ "2", "3", "4", "5", "6", "7", "8", "9" }, char_1) then
 				n = tonumber(char_1) - 1
 				char_1 = utils.get_surround_chars()
+				if char_1 == nil then
+					return
+				end
 			end
 			char_2 = utils.get_surround_chars()
+			if char_2 == nil then
+				return
+			end
 		end
 	end
 

--- a/lua/surround/init.lua
+++ b/lua/surround/init.lua
@@ -682,6 +682,7 @@ function M.setup(opts)
 	set_default("mappings_style", "sandwich")
 	set_default("map_insert_mode", true)
 	set_default("prefix", "s")
+	set_default("prompt", true)
 	set_default("load_autogroups", false)
 	if vim.g.surround_load_autogroups then
 		M.load_autogroups({

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -354,13 +354,14 @@ local function get_motion()
 		-- 27 is <ESC>
 		if char_raw == 27 then return nil end
 
-		if motion == "" and char_string == "0" then
+		if count .. motion == "" and char_string == "0" then
 			-- "0" motion (beginning of line) does not take a count
 			return "0"
 		end
 
 		if "0" <= char_string and char_string <= "9" and not count_complete then
 			count = count .. char_string
+			msg = msg .. char_string
 		else
 			count_complete = true
 			motion = motion .. char_string

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -1,3 +1,16 @@
+local function clear_output_buffer()
+	vim.api.nvim_call_function("inputsave", {})
+	vim.api.nvim_feedkeys(":","nx", true)
+	vim.api.nvim_call_function("inputrestore", {})
+end
+
+local function log(string, history)
+	if vim.g.surround_prompt then
+		clear_output_buffer()
+		vim.api.nvim_echo({{string, nil}}, history, {})
+	end
+end
+
 local function get(var, def)
 	if var == nil then
 		return def
@@ -230,12 +243,6 @@ local function has_value(tab, val)
 	return false
 end
 
-local function clear_output_buffer()
-	vim.api.nvim_call_function("inputsave", {})
-	vim.api.nvim_feedkeys(':','nx', true)
-	vim.api.nvim_call_function("inputrestore", {})
-end
-
 local function get_char()
 	local char_raw = vim.fn.getchar()
 	if type(char_raw) == "number" then
@@ -248,20 +255,14 @@ end
 
 local function get_surround_chars(surrounding)
 	if not surrounding then
-		vim.api.nvim_command(':echo "(Surround) Character: "')
+		log("(Surround) Character: ", false)
 		local char_nr
 		char_nr, surrounding = get_char()
 
 		-- 27 is <ESC>
 		if char_nr == 27 then return nil end
 
-		clear_output_buffer()
-		-- escape characters
-		if not string.isalnum(surrounding) then
-			vim.api.nvim_command(':echomsg "(Surround) Character: \\' .. surrounding .. '"')
-		else
-			vim.api.nvim_command(':echomsg "(Surround) Character: ' .. surrounding .. '"')
-		end
+		log("(Surround) Character: " .. string.escape_dquotes(surrounding), true)
 	end
 
 	for i,v in pairs(vim.g.surround_pairs_flat) do
@@ -347,8 +348,7 @@ local function get_motion()
 	local count_complete = false
 	local o_maps = omaps()
 	while true do
-		clear_output_buffer()
-		vim.api.nvim_command(":echo '(Surround) Motion: " .. msg .. "'")
+		log("(Surround) Motion: " .. msg, false)
 		local char_raw, char_string = get_char()
 
 		-- 27 is <ESC>
@@ -398,15 +398,13 @@ local function get_motion()
 				and not table.contains(MOTIONS_ESC["incomplete"], last_char))
 				or custom_omap)
 			then
-				clear_output_buffer()
-				vim.api.nvim_command(':echomsg "(Surround) Motion: ' .. msg .. ' ❌ (invalid)"')
+				log("(Surround) Motion: " .. msg .. " ❌ (invalid)", true)
 				return nil
 			end
 		end
 		last_char = char_string
 	end
-	clear_output_buffer()
-	vim.api.nvim_command(':echomsg "(Surround) Motion: ' .. msg .. ' ✅"')
+	log("(Surround) Motion: " .. msg .. " ✅", true)
 	return count..motion
 end
 
@@ -432,6 +430,8 @@ local function highlight_motion_selection()
 end
 
 return {
+	clear_output_buffer = clear_output_buffer,
+	log = log,
 	tprint = tprint,
 	has_value = has_value,
 	user_input = user_input,
@@ -444,7 +444,6 @@ return {
 	get_char_pair = get_char_pair,
 	get_surround_chars = get_surround_chars,
 	get_char = get_char,
-	clear_output_buffer = clear_output_buffer,
 	load_keymaps = load_keymaps,
 	quote = quote,
 	get = get,

--- a/lua/surround/utils.lua
+++ b/lua/surround/utils.lua
@@ -260,7 +260,10 @@ local function get_surround_chars(surrounding)
 		char_nr, surrounding = get_char()
 
 		-- 27 is <ESC>
-		if char_nr == 27 then return nil end
+		if char_nr == 27 then
+			log("(Surround) Character: ❌", true)
+			return
+		end
 
 		log("(Surround) Character: " .. string.escape_dquotes(surrounding), true)
 	end


### PR DESCRIPTION
Adds a new option `vim.g.surround_prompt` that controls whether a prompt should be shown in the command window when requesting input.

Also adds a bunch of `if char == nil then return end` statements so that the plugin aborts immediately instead of potentially asking for a second character anyways.